### PR TITLE
chore(compose): tidy volume config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,16 +3,21 @@ version: '3.8'
 
 services:
   geth:
+    container_name: geth
     image: ethereum/client-go:stable
     volumes:
       - geth-data:/data
-      - ./jwt.hex:/geth/jwt.hex:ro
+      - type: bind
+        source: ./jwt.hex
+        target: /geth/jwt.hex
+        read_only: true
     tmpfs:
       - /tmp
     ports:
-      - "8545:8545"
+      - "127.0.0.1:8545:8545"     # JSON-RPC local-only
       - "8551:8551"
       - "30303:30303"
+      - "30303:30303/udp"
     ulimits:
       nofile:
         soft: 100000
@@ -29,14 +34,21 @@ services:
       - --authrpc.vhosts=*
       - --syncmode=snap
       - --cache=4096
+      - --maxpeers=100
+      - --bootnodes=enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666@18.138.108.67:30303,enode://22a8232c3abc76a16ae9d6c3b164f98775fe226f0917b0ca871128a74a8e9630b458460865bab457221f1d448dd9791d24c4e5d88786180ac185df813a68d4de@3.209.45.79:30303,enode://2b252ab6a1d0f971d9722cb839a42cb81db019ba44c08754628ab4a823487071b5695317c8ccd085219c3a03af063495b2f1da8d18218da2d6a82981b45e6ffc@65.108.70.101:30303
       - --metrics
       - --metrics.addr=0.0.0.0
+    restart: unless-stopped
 
   prysm:
+    container_name: prysm
     image: gcr.io/prysmaticlabs/prysm/beacon-chain:stable
     volumes:
       - prysm-data:/data
-      - ./jwt.hex:/geth/jwt.hex:ro
+      - type: bind
+        source: ./jwt.hex
+        target: /geth/jwt.hex
+        read_only: true
     tmpfs:
       - /tmp
     ports:
@@ -51,15 +63,17 @@ services:
       - --datadir=/data
       - --execution-endpoint=http://geth:8551
       - --jwt-secret=/geth/jwt.hex
+      - --checkpoint-sync-url=https://beaconstate.ethstaker.cc
+      - --genesis-beacon-api-url=https://beaconstate.ethstaker.cc
       - --rpc-host=0.0.0.0
       - --grpc-gateway-host=0.0.0.0
       - --monitoring-host=0.0.0.0
+      - --max-peers=100
       - --accept-terms-of-use
     depends_on:
       - geth
+    restart: unless-stopped
 
 volumes:
   geth-data:
-    driver: local
   prysm-data:
-    driver: local


### PR DESCRIPTION
- drop explicit  (default anyway)
- keep named volumes  and  for durable chain data
-  use explicit bind mount for jwt.hex to avoid file vs dir mount error